### PR TITLE
"Протокол Oauth.Исправление замечаний"

### DIFF
--- a/app/controllers/oauth_callbacks_controller.rb
+++ b/app/controllers/oauth_callbacks_controller.rb
@@ -1,17 +1,23 @@
 class OauthCallbacksController < Devise::OmniauthCallbacksController
-  before_action :session_data, only: %i[github facebook]
-
   def github
-    log_in(session['omniauth.auth'])
+    log_in(request.env['omniauth.auth'])
   end
 
   def facebook
-    log_in(session['omniauth.auth'])
+    log_in(request.env['omniauth.auth'])
   end
 
   def set_email
-    session['omniauth.auth']['info']['user_email'] = params[:email]
-    log_in(session['omniauth.auth'])
+    password = Devise.friendly_token[0, 20]
+    user = User.new(email: params[:email], password: password, password_confirmation: password)
+    if user.save
+      user.authorizations.create(provider: session[:provider], uid: session[:uid])
+      session[:provider] = nil
+      session[:uid] = nil
+      redirect_to root_path, notice: 'You need to confirm your email'
+    else
+      render 'confirmations/email', locals: { user: user }
+    end
   end
 
   private
@@ -20,18 +26,16 @@ class OauthCallbacksController < Devise::OmniauthCallbacksController
     @user = User.find_for_oauth(service)
     if @user&.persisted? && @user&.confirmed_at?
       sign_in_and_redirect @user, event: :authentication
-      set_flash_message(:notice, :success, kind: service['provider'].capitalize) if is_navigational_format? && service
+      set_flash_message(:notice, :success, kind: service.provider.capitalize) if is_navigational_format? && service
     elsif @user&.persisted? && !@user&.confirmed_at?
       flash[:alert] = 'You need to confirm your email'
       redirect_to new_user_session_path
     elsif service
-      render 'confirmations/email', locals: { provider: session['omniauth.auth']['provider'], user: @user }
+      session[:provider] = service[:provider]
+      session[:uid] = service[:uid].to_s
+      render 'confirmations/email', locals: { user: @user }
     else
       redirect_to root_path, alert: 'Something went wrong'
     end
-  end
-
-  def session_data
-    session['omniauth.auth'] = request.env['omniauth.auth']
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,6 @@ class User < ApplicationRecord
   end
 
   def create_authorization(auth)
-    authorizations.create(provider: auth['provider'], uid: auth['uid']) if persisted?
+    authorizations.create(provider: auth.provider, uid: auth.uid) if persisted?
   end
 end

--- a/app/services/find_for_oauth.rb
+++ b/app/services/find_for_oauth.rb
@@ -6,21 +6,16 @@ class FindForOauth
   end
 
   def call
-    authorization = Authorization.where(provider: auth['provider'], uid: auth['uid'].to_s).first
+    authorization = Authorization.where(provider: auth.provider, uid: auth.uid.to_s).first
     return authorization.user if authorization
 
-    email = auth['info']['email'] if auth['info'] && auth['info']['email']
-    user_email = auth['info']['user_email'] if auth['info'] && auth['info']['user_email']
+    email = auth.info[:email]
 
     user = User.where(email: email).first
     if user
       user.create_authorization(auth)
-    elsif email
-      user = User.create(email: email, password: set_password, password_confirmation: set_password, confirmed_at: Time.now)
-      user.create_authorization(auth)
     else
-      # noinspection RubyScope
-      user = User.create(email: user_email, password: set_password, password_confirmation: set_password)
+      user = User.create(email: email, password: set_password, password_confirmation: set_password, confirmed_at: Time.now)
       user.create_authorization(auth)
     end
     user

--- a/spec/controllers/oauth_callbacks_controller_spec.rb
+++ b/spec/controllers/oauth_callbacks_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe OauthCallbacksController, type: :controller do
   end
 
   describe 'Github' do
-    let(:oauth_data) { { 'provider' => 'github', 'uid' => 123 } }
+    let(:oauth_data) { { provider: 'github', uid: 123 } }
 
     it 'finds user from oauth data' do
       allow(request.env).to receive(:[]).and_call_original
@@ -49,7 +49,7 @@ RSpec.describe OauthCallbacksController, type: :controller do
   end
 
   describe 'Facebook' do
-    let(:oauth_data) { { 'provider' => 'facebook', 'uid' => 123 } }
+    let(:oauth_data) { { provider: 'facebook', uid: 123 } }
 
     it 'finds user from oauth data' do
       allow(request.env).to receive(:[]).and_call_original

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -32,7 +32,7 @@ describe 'User can sign in', "
 
       describe 'Registered user' do
         it 'try to sign in' do
-          mock_auth_hash(network.downcase, email: 'test@mail.ru')
+          mock_auth_hash(network.downcase, email: user.email)
           click_on "Sign in with #{network}"
           expect(page).to have_content "Successfully authenticated from #{network.capitalize} account."
         end
@@ -54,7 +54,7 @@ describe 'User can sign in', "
         end
 
         context "#{network} not return email" do
-          it 'user try type exist email' do
+          it 'try type exist email' do
             mock_auth_hash(network.downcase, email: nil)
             click_on "Sign in with #{network}"
             expect(page).to have_content 'Add your email address for sign in'

--- a/spec/services/find_for_oauth_spec.rb
+++ b/spec/services/find_for_oauth_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe FindForOauth do
     end
 
     context 'provider not return email' do
-      let(:auth) { OmniAuth::AuthHash.new(provider: 'github', uid: '123456', info: { user_email: 'new@user.com' }) }
+      let(:auth) { OmniAuth::AuthHash.new(provider: 'github', uid: '123456', info: { email: 'new@user.com' }) }
 
       it 'oauth_provider not return email' do
         expect { subject.call }.to change(User, :count).by(1)


### PR DESCRIPTION
Реализовать аутентификацию через Github и любой другой соц. сети, на выбор (Twitter, VK и т.п.).
Обязательно покрыть acceptance и unit-тестами (как тестировать описано в доп. материалах к уроку).

Усложненное задание:
Реализовать обработку случая, когда провайдер не возвращает email (VK и другие провайдеры теперь умеют атуентифицировать по номеру телефона, а не по email. По-умолчанию Twitter тоже не возвращает email, поэтому на нем проще всего протестировать):
В этом случае, в первый раз запросить у пользователя email, а затем отослать на письмо на указанный email со ссылкой на подтверждение этого email. Не аутентифицировать пользователя до тех пор, пока он не подтвердит указанный email. После подтверждения, пользователь может входить через выбранного провайдера без дополнительных запросов на ввод или подтверждение email.

Примечания:

В dev-окружении не стоит использовать реальную отправку писем, т.к. настройки могут быть у разработчиков разные, да и нет смысла слать реальные письма при разработке. Лучше использовать гем letter_opener (ссылка есть в доп. материалах к уроку), который откроет письма в браузере.
Для того, чтобы в acceptance-тестах можно было "открывать" письма и взаимодействовать с ними (например, кликать по ссылкам) рекомендуется gem capybara-email (ссылка есть в доп. материалах к уроку)